### PR TITLE
`UNION` and `UNION ALL` operators explanation added 

### DIFF
--- a/sql/introduction.md
+++ b/sql/introduction.md
@@ -35,6 +35,9 @@ An INNER JOIN will combine rows from different tables if the *join condition* is
 ### OUTER JOIN
 An outer join will combine rows from different tables even if the join condition is not met. Every row in the *left* table is returned in the result set, and if the join condition is not met, then `NULL` values are used to fill in the columns from the *right* table.
 
+### UNION / UNION ALL
+The `UNION` operator is used to combine the result-set of two or more `SELECT` statements. `UNION` removes duplicate rows between the various `SELECT` statements, while `UNION ALL` includes all rows, including duplicates. Each `SELECT` statement within `UNION` must have the same number of columns with similar data types and in the same order.
+
 ### UPDATE
 `UPDATE` statements allow you to edit rows in a table.
 


### PR DESCRIPTION
This pull request adds a new section to the SQL introduction documentation to explain the `UNION` and `UNION ALL` operators. The new section describes the purpose, behavior, and requirements of these operators when combining results from multiple `SELECT` statements.

Documentation updates:

* Added a section in `sql/introduction.md` explaining the `UNION` and `UNION ALL` operators, including their differences and usage requirements.